### PR TITLE
Fix pre-activation implementation; add regularization 

### DIFF
--- a/cifar10.py
+++ b/cifar10.py
@@ -6,8 +6,24 @@ from __future__ import print_function
 from keras.datasets import cifar10
 from keras.preprocessing.image import ImageDataGenerator
 from keras.utils import np_utils
+from keras.callbacks import LearningRateScheduler
 
 import resnet
+
+def _lr_schedule(epoch):
+    if epoch<75:
+        print('')
+        print('lr = 1.e-3')
+        return 1.e-3
+    elif epoch<150:
+        print('')
+        print('lr = 1.e-4')
+        return 1.e-4
+    else:
+        print('')
+        print('lr = 1.e-5')
+        return 1.e-5
+
 
 batch_size = 32
 nb_classes = 10
@@ -33,7 +49,7 @@ model = resnet.ResnetBuilder.build_resnet_18((img_channels, img_rows, img_cols),
 
 # Let's train the model using RMSprop
 model.compile(loss='categorical_crossentropy',
-              optimizer='rmsprop',
+              optimizer='adam',
               metrics=['accuracy'])
 
 X_train = X_train.astype('float32')
@@ -47,7 +63,8 @@ if not data_augmentation:
               batch_size=batch_size,
               nb_epoch=nb_epoch,
               validation_data=(X_test, Y_test),
-              shuffle=True)
+              shuffle=True,
+              callbacks = [LearningRateScheduler(_lr_schedule)])
 else:
     print('Using real-time data augmentation.')
     # This will do preprocessing and realtime data augmentation:
@@ -71,4 +88,5 @@ else:
     model.fit_generator(datagen.flow(X_train, Y_train, batch_size=batch_size),
                         samples_per_epoch=X_train.shape[0],
                         validation_data=(X_test, Y_test),
-                        nb_epoch=nb_epoch, verbose=2, max_q_size=1000)
+                        nb_epoch=nb_epoch, verbose=1,
+                        callbacks = [LearningRateScheduler(_lr_schedule)])

--- a/cifar10.py
+++ b/cifar10.py
@@ -1,29 +1,23 @@
 """
-Train a simple deep CNN on the CIFAR10 small images dataset.
+Adapted from keras example cifar10_cnn.py
+Train ResNet-18 on the CIFAR10 small images dataset.
+
+GPU run command with Theano backend (with TensorFlow, the GPU is automatically used):
+    THEANO_FLAGS=mode=FAST_RUN,device=gpu,floatX=float32 python cifar10.py
 """
 
 from __future__ import print_function
 from keras.datasets import cifar10
 from keras.preprocessing.image import ImageDataGenerator
 from keras.utils import np_utils
-from keras.callbacks import LearningRateScheduler
+from keras.callbacks import ReduceLROnPlateau, CSVLogger, EarlyStopping
+import numpy as np
 
 import resnet
 
-def _lr_schedule(epoch):
-    if epoch<75:
-        print('')
-        print('lr = 1.e-3')
-        return 1.e-3
-    elif epoch<150:
-        print('')
-        print('lr = 1.e-4')
-        return 1.e-4
-    else:
-        print('')
-        print('lr = 1.e-5')
-        return 1.e-5
-
+lr_reducer = ReduceLROnPlateau(monitor='val_loss', factor=np.sqrt(0.1), cooldown=0, patience=5, min_lr=0.5e-6)
+early_stopper = EarlyStopping(monitor='val_acc', min_delta=0.001, patience=10)
+csv_logger = CSVLogger('resnet18_cifar10.csv')
 
 batch_size = 32
 nb_classes = 10
@@ -45,17 +39,20 @@ print(X_test.shape[0], 'test samples')
 Y_train = np_utils.to_categorical(y_train, nb_classes)
 Y_test = np_utils.to_categorical(y_test, nb_classes)
 
-model = resnet.ResnetBuilder.build_resnet_18((img_channels, img_rows, img_cols), nb_classes)
+X_train = X_train.astype('float32')
+X_test = X_test.astype('float32')
 
-# Let's train the model using RMSprop
+# subtract mean and normalize
+mean_image = np.mean(X_train, axis=0)
+X_train -= mean_image
+X_test -= mean_image
+X_train /= 128.
+X_test /= 128.
+
+model = resnet.ResnetBuilder.build_resnet_18((img_channels, img_rows, img_cols), nb_classes)
 model.compile(loss='categorical_crossentropy',
               optimizer='adam',
               metrics=['accuracy'])
-
-X_train = X_train.astype('float32')
-X_test = X_test.astype('float32')
-X_train /= 255
-X_test /= 255
 
 if not data_augmentation:
     print('Not using data augmentation.')
@@ -64,7 +61,7 @@ if not data_augmentation:
               nb_epoch=nb_epoch,
               validation_data=(X_test, Y_test),
               shuffle=True,
-              callbacks = [LearningRateScheduler(_lr_schedule)])
+              callbacks = [lr_reducer, early_stopper, csv_logger])
 else:
     print('Using real-time data augmentation.')
     # This will do preprocessing and realtime data augmentation:
@@ -89,4 +86,4 @@ else:
                         samples_per_epoch=X_train.shape[0],
                         validation_data=(X_test, Y_test),
                         nb_epoch=nb_epoch, verbose=1,
-                        callbacks = [LearningRateScheduler(_lr_schedule)])
+                        callbacks = [lr_reducer, early_stopper, csv_logger])

--- a/resnet.py
+++ b/resnet.py
@@ -132,7 +132,7 @@ def bottleneck(nb_filter, init_subsample=(1, 1), is_first_block_of_first_layer=F
                                  init="he_normal", border_mode="same",
                                  W_regularizer=l2(0.0001))(input)
         else:
-            conv_1_1 = _bn_relu_conv(nb_filter, 1, 1, subsample=init_subsample)(input)
+            conv_1_1 = _bn_relu_conv(nb_filter=nb_filter, nb_row=1, nb_col=1, subsample=init_subsample)(input)
 
         conv_3_3 = _bn_relu_conv(nb_filter=nb_filter, nb_row=3, nb_col=3)(conv_1_1)
         residual = _bn_relu_conv(nb_filter=nb_filter * 4, nb_row=1, nb_col=1)(conv_3_3)

--- a/resnet.py
+++ b/resnet.py
@@ -12,6 +12,7 @@ from keras.layers.convolutional import (
     AveragePooling2D
 )
 from keras.layers.normalization import BatchNormalization
+from keras.regularizers import l2
 from keras import backend as K
 
 # Helper to build a BN -> relu block
@@ -24,7 +25,7 @@ def _bn_relu(input):
 def _conv_bn_relu(nb_filter, nb_row, nb_col, subsample=(1, 1)):
     def f(input):
         conv = Convolution2D(nb_filter=nb_filter, nb_row=nb_row, nb_col=nb_col, subsample=subsample,
-                             init="he_normal", border_mode="same")(input)
+                             init="he_normal", border_mode="same", W_regularizer=l2(0.0001))(input)
         return _bn_relu(conv)
 
     return f
@@ -36,7 +37,7 @@ def _bn_relu_conv(nb_filter, nb_row, nb_col, subsample=(1, 1)):
     def f(input):
         activation = _bn_relu(input)
         return Convolution2D(nb_filter=nb_filter, nb_row=nb_row, nb_col=nb_col, subsample=subsample,
-                             init="he_normal", border_mode="same")(activation)
+                             init="he_normal", border_mode="same", W_regularizer=l2(0.0001))(activation)
 
     return f
 
@@ -56,7 +57,8 @@ def _shortcut(input, residual):
         shortcut = Convolution2D(nb_filter=residual._keras_shape[CHANNEL_AXIS],
                                  nb_row=1, nb_col=1,
                                  subsample=(stride_width, stride_height),
-                                 init="he_normal", border_mode="valid")(input)
+                                 init="he_normal", border_mode="valid",
+                                 W_regularizer=l2(0.0001))(input)
 
     return merge([shortcut, residual], mode="sum")
 
@@ -89,7 +91,8 @@ def basic_block(nb_filters, init_subsample=(1, 1), is_first_block_of_first_layer
             conv1 = Convolution2D(nb_filter=nb_filters,
                                  nb_row=3, nb_col=3,
                                  subsample=init_subsample,
-                                 init="he_normal", border_mode="same")(input)
+                                 init="he_normal", border_mode="same",
+                                 W_regularizer=l2(0.0001))(input)
         else:
             conv1 = _bn_relu_conv(nb_filters, 3, 3, subsample=init_subsample)(input)
 
@@ -110,7 +113,8 @@ def bottleneck(nb_filters, init_subsample=(1, 1), is_first_block_of_first_layer=
             conv_1_1 = Convolution2D(nb_filter=nb_filters,
                                  nb_row=1, nb_col=1,
                                  subsample=init_subsample,
-                                 init="he_normal", border_mode="same")(input)
+                                 init="he_normal", border_mode="same",
+                                 W_regularizer=l2(0.0001))(input)
         else:
             conv_1_1 = _bn_relu_conv(nb_filters, 1, 1, subsample=init_subsample)(input)
 

--- a/resnet.py
+++ b/resnet.py
@@ -14,14 +14,20 @@ from keras.layers.convolutional import (
 from keras.layers.normalization import BatchNormalization
 from keras import backend as K
 
+# Helper to build a BN -> relu block
+def _bn_relu():
+    def f(input):
+        norm = BatchNormalization(mode=0, axis=CHANNEL_AXIS)(input)
+        return Activation("relu")(norm)
+
+    return f
 
 # Helper to build a conv -> BN -> relu block
 def _conv_bn_relu(nb_filter, nb_row, nb_col, subsample=(1, 1)):
     def f(input):
         conv = Convolution2D(nb_filter=nb_filter, nb_row=nb_row, nb_col=nb_col, subsample=subsample,
                              init="he_normal", border_mode="same")(input)
-        norm = BatchNormalization(mode=0, axis=CHANNEL_AXIS)(conv)
-        return Activation("relu")(norm)
+        return _bn_relu(conv)
 
     return f
 
@@ -30,8 +36,7 @@ def _conv_bn_relu(nb_filter, nb_row, nb_col, subsample=(1, 1)):
 # This is an improved scheme proposed in http://arxiv.org/pdf/1603.05027v2.pdf
 def _bn_relu_conv(nb_filter, nb_row, nb_col, subsample=(1, 1)):
     def f(input):
-        norm = BatchNormalization(mode=0, axis=CHANNEL_AXIS)(input)
-        activation = Activation("relu")(norm)
+        activation = _bn_relu(input)
         return Convolution2D(nb_filter=nb_filter, nb_row=nb_row, nb_col=nb_col, subsample=subsample,
                              init="he_normal", border_mode="same")(activation)
 

--- a/resnet.py
+++ b/resnet.py
@@ -15,12 +15,10 @@ from keras.layers.normalization import BatchNormalization
 from keras import backend as K
 
 # Helper to build a BN -> relu block
-def _bn_relu():
-    def f(input):
-        norm = BatchNormalization(mode=0, axis=CHANNEL_AXIS)(input)
-        return Activation("relu")(norm)
+def _bn_relu(input):
+    norm = BatchNormalization(mode=0, axis=CHANNEL_AXIS)(input)
+    return Activation("relu")(norm)
 
-    return f
 
 # Helper to build a conv -> BN -> relu block
 def _conv_bn_relu(nb_filter, nb_row, nb_col, subsample=(1, 1)):


### PR DESCRIPTION
- Addresses issues #25 and #26 by adding L2 regularization (weight decay) and using pre-activations according to paper
- Changes optimizer from RMSprop to Adam (see https://github.com/fchollet/keras/issues/4897)
https://github.com/raghakot/keras-resnet/issues/26
- Adds learning rate scheduler to cifar10.py
- Achieves about 87.8% in cifar10.py experiment
- Note that ResNet18 as implemented doesn't really seem appropriate for CIFAR-10 as the last two residual stages end up as all 1x1 convolutions from downsampling (stride). This is worse for deeper versions. Using a smaller, modified [ResNet-like architecture](https://gist.github.com/JefferyRPrice/c1ecc3d67068c8d9b3120475baba1d7e), I was able to achieve 92% on CIFAR-10.
