### PR TITLE
Added batch norm and activation before avg pooling

### DIFF
--- a/resnet.py
+++ b/resnet.py
@@ -145,10 +145,13 @@ class ResnetBuilder(object):
             block = _residual_block(block_fn, nb_filters=nb_filters, repetitions=r, is_first_layer=i == 0)(block)
             nb_filters *= 2
 
+        block_norm = BatchNormalization(mode=0, axis=CHANNEL_AXIS)(block)
+        block_output = Activation("relu")(block_norm)
+
         # Classifier block
         pool2 = AveragePooling2D(pool_size=(block._keras_shape[ROW_AXIS],
                                             block._keras_shape[COL_AXIS]),
-                                 strides=(1, 1))(block)
+                                 strides=(1, 1))(block_output)
         flatten1 = Flatten()(pool2)
         dense = Dense(output_dim=num_outputs, init="he_normal", activation="softmax")(flatten1)
 


### PR DESCRIPTION
The code uses batch norm -> relu -> conv sequence which is not a standard resnet but resnet with identity mappings:
https://arxiv.org/pdf/1603.05027v3.pdf

Resnet IM requires additional batch norm and activation after the last residual block and before average pooling.

Added that.