### PR TITLE
Add setup.py, resolve name shadowing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# packaging-related
+*.egg-info/
+
 # test-related
 .coverage
 .cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
     include:
         - python: 2.7
           env: KERAS_BACKEND=theano
+          env: MKL_THREADING_LAYER=GNU
         - python: 2.7
           env: KERAS_BACKEND=tensorflow
         - python: 3.4
@@ -31,6 +32,8 @@ install:
 
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pandas pytest h5py
   - source activate test-environment
+  # Prevent py2 theano build getting upset
+  - conda install -q -y mkl-service
   - pip install git+git://github.com/Theano/Theano.git
   - pip install keras
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,28 @@ There are two key aspects to note here
  2. At the end of the first skip connection of a block, there is a disconnect in num_filters, width and height at the merge layer. This is addressed in [`_shortcut`](https://github.com/raghakot/keras-resnet/blob/master/resnet.py#L41) by using `conv 1X1` with an appropriate stride.
  For remaining cases, input is directly merged with residual block as identity.
 
-### ResNetBuilder factory
+### Usage
+
+Install your backend of choice ([theano](http://deeplearning.net/software/theano/install.html)/
+[tensorflow](https://www.tensorflow.org/install/)), and then
+
+```bash
+pip install git+git://github.com/raghakot/keras-resnet.git
+```
+
+From python:
+
+```python
+from resnet import ResnetBuilder
+
+INPUT_SHAPE = (32, 32)
+OUTPUT_CLASSES = 10
+
+model = ResnetBuilder.build_resnet_18(INPUT_SHAPE, OUTPUT_CLASSES)
+
+# train and use model as appropriate
+```
+
 - Use ResNetBuilder [build](https://github.com/raghakot/keras-resnet/blob/master/resnet.py#L135-L153) methods to build standard ResNet architectures with your own input shape. It will auto calculate paddings and final pooling layer filters for you.
 - Use the generic [build](https://github.com/raghakot/keras-resnet/blob/master/resnet.py#L99) method to setup your own architecture.
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+import os
+
+from setuptools import setup
+
+with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.md')) as f:
+    long_description = f.read()
+
+setup(
+    name='keras-resnet',
+    version='0.0.1',
+    description='Residual networks implementation using Keras-1.0 functional API',
+    long_description=long_description,
+    url='https://github.com/raghakot/keras-resnet',
+    author='raghakot',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ],
+    keywords='keras resnet residual-networks deep-learning cnn',
+    py_modules=['resnet'],
+    install_requires=['keras>=1.0', 'six'],
+    extras_require={
+        'test': ['pytest'],
+    },
+)


### PR DESCRIPTION
- Adding a `setup.py` allows others to use the `ResnetBuilder` in a more tidy and traceable way.
- Variables called `input`  were renamed to `input_data` to resolve name clashes with the builtin `input`

Versioning is left up to @raghakot 